### PR TITLE
build: modernize package for Laravel 11/12 and PHP 8.2+

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,17 +21,14 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.4, 8.3]
-        laravel: [12.*, 11.*, 10.*]
+        php: [8.4, 8.3, 8.2]
+        laravel: [12.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*
             testbench: 9.*
-          - laravel: 10.*
-            testbench: ^8.22
-    
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ That's it! Your model now has full approval functionality. 🎉
 
 ### Requirements
 
-- PHP 8.1 or higher
-- Laravel 9 or higher
+- PHP 8.2 or higher
+- Laravel 11.0 | 12.0
 
 ### Install via Composer
 

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
         }
     ],
     "require": {
-        "php": "^8.3",
+        "php": "^8.2",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^10.0||^11.0||^12.0"
+        "illuminate/contracts": "^11.0||^12.0"
     },
     "require-dev": {
         "larastan/larastan": "^2.9||^3.0",


### PR DESCRIPTION
- Drop support for Laravel 10 and PHP 8.1 (EOL)

- Add support for Laravel 12

- Require PHP 8.2+

- Update documentation to match new requirements